### PR TITLE
Task 4

### DIFF
--- a/pdf merger& spliter.py
+++ b/pdf merger& spliter.py
@@ -1,0 +1,30 @@
+from PyPDF2 import PdfMerger, PdfReader, PdfWriter
+import os
+
+def merge_pdfs(input_paths, output_path):
+    merger = PdfMerger()
+    for path in input_paths:
+        merger.append(path)
+    merger.write(output_path)
+    merger.close()
+    print("PDFs merged successfully!")
+
+def split_pdf(input_path):
+    input_pdf = PdfReader(open(input_path, "rb"))
+    input_filename = os.path.splitext(os.path.basename(input_path))[0]
+
+    for i in range(len(input_pdf.pages)):
+        output_pdf = PdfWriter()
+        output_pdf.add_page(input_pdf.pages[i])
+        output_path = f"{input_filename}page{i+1}.pdf"
+        with open(output_path, "wb") as output_file:
+            output_pdf.write(output_file)
+        print(f"Page {i+1} extracted successfully to {output_path}")
+
+# Example usage:
+# Merge PDFs
+input_files = ["pdf1.pdf", "pdf2.pdf", "pdf3.pdf"]
+merge_pdfs(input_files, "merged.pdf")
+
+# Split PDF
+split_pdf("input.pdf")


### PR DESCRIPTION
Online Tools:

Websites like Smallpdf, PDF Merge, or ILovePDF offer free online tools to merge PDF files. They usually allow you to upload multiple PDFs, arrange them in the desired order, and merge them into a single PDF file that you can download. Desktop Software:

Adobe Acrobat Pro: This is a paid software that allows you to merge PDF files among its many features. PDFsam (PDF Split and Merge): This is a free and open-source software that lets you merge, split, rotate, and mix PDF files. Using Preview (Mac):

If you're on a Mac, you can use the built-in Preview app to merge PDFs. Open one PDF in Preview, then drag the other PDFs into the sidebar of the open document. PDF Splitter:
Online Tools:

Similar to merging, online tools like Smallpdf, PDF Split, or ILovePDF also offer PDF splitting services. You upload your PDF, select the pages or ranges you want to split, and download the resulting PDFs. Adobe Acrobat Pro:

This software can also split PDF files. You can specify the pages or ranges you want to extract into separate PDFs. PDFsam:

PDFsam can be used not only for merging but also for splitting PDF files. It allows you to split by pages, bookmarks, or even by size. Using Preview (Mac):

On a Mac, Preview can also split PDFs. Open the PDF in Preview, select the pages you want to extract, then drag them out into a Finder window to create a new PDF. Considerations:
Security: Ensure that any online tools you use are secure, especially if your PDFs contain sensitive information.

Quality: Some tools might compress PDFs during the merging or splitting process, potentially reducing image quality or text sharpness.